### PR TITLE
this one need a bn bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
   sha256: d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
 
 build:
-  number: 1000
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 1001
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed ."
 
 requirements:
   host:


### PR DESCRIPTION
We had a name package conflict with the pre-3.8 label. This may happen with other packages too.

See https://github.com/conda-forge/six-feedstock/pull/19#issuecomment-549047158

Thanks @xylar for point this to me!